### PR TITLE
issure #12 Add dont_change option for "table_transform" and "column_t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ Values that are wrapped in `%` symbols are treated as varaibles and evaluated at
 |
 +-- column_mapping                    struct - maps column names if needed, e.g. "group" -> "group_name"
 |
-+-- table_transform                   string - ([""], "lower_case", "upper_case", "camel_to_snake_case")
++-- table_transform                   string - ([""], "lower_case", "upper_case", "camel_to_snake_case", "dont_change")
 |
-+-- column_transform                  string - ([""], "lower_case", "upper_case", "camel_to_snake_case")
++-- column_transform                  string - ([""], "lower_case", "upper_case", "camel_to_snake_case", "dont_change")
 |
 +-- ddl
     |

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,14 @@
                     </archive>
                 </configuration>
             </plugin>
+			 <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.1</version>
+            <configuration>
+                <fork>true</fork>
+                <executable>C:\Program Files\Java\jdk1.8.0_202\bin\javac.exe</executable>
+            </configuration>
+        </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/net/twentyonesolutions/m2pg/Config.java
+++ b/src/main/java/net/twentyonesolutions/m2pg/Config.java
@@ -340,6 +340,9 @@ public class Config {
 
             if (type.equalsIgnoreCase("camel_to_snake_case"))
                 return Util.convertCamelToSnakeCase(input);
+			
+			if (type.equalsIgnoreCase("dont_change"))
+                return Util.convertDontChangeCase(input);
         }
 
         return input;

--- a/src/main/java/net/twentyonesolutions/m2pg/Util.java
+++ b/src/main/java/net/twentyonesolutions/m2pg/Util.java
@@ -71,6 +71,16 @@ public class Util {
                 .replaceAll("([^_A-Z0-9])([A-Z0-9])", "$1_$2")
                 .toLowerCase();
     }
+	
+	 /**
+     * If it is necessary to do not change case, add  quote to input string;
+     *
+     * @param anyCaseString
+     * @return
+     */
+	public static String convertDontChangeCase(String anyCaseString){
+		return "\""+anyCaseString+"\"";
+	}
 
 
     public static Map<String, Object> flattenKeys(Map<String, Object> map){


### PR DESCRIPTION
…ransform"

This commit add option "dont_change" for parametres "table_transform" and "column_transform". With that option case of table names and column names does not changed via migration.